### PR TITLE
Update PDL Political Science Collection to 0.0.19 release

### DIFF
--- a/corpus.json
+++ b/corpus.json
@@ -1,12 +1,12 @@
 {
-  "PerseusDL/canonical-latinLit": "master",
-  "PerseusDL/canonical-greekLit": "master",
-  "OpenGreekAndLatin/csel-dev": "master",
-  "PerseusDL/canonical-farsiLit": "master",
-  "PerseusDL/canonical-pdlpsci": "master",
-  "OpenGreekAndLatin/First1KGreek": "master",
-  "lascivaroma/priapeia": "master",
-  "hlapin/ancJewLitCTS": "master",
+  "PerseusDL/canonical-latinLit": "c001efb82bc26ba95e935ce2fb4756d1dff0a688",
+  "PerseusDL/canonical-greekLit": "8403e88376cd3e844d2c93d79f05742788b971c7",
+  "OpenGreekAndLatin/csel-dev": "fe80c57e88302917eaeac5dc6ecc81be5f3fb83a",
+  "PerseusDL/canonical-farsiLit": "1ce632ece8a2af0646195a0531f5e8f39b161f72",
+  "PerseusDL/canonical-pdlpsci": "ff20d572cfdfeac871322ca07db4d34c5b7807da",
+  "OpenGreekAndLatin/First1KGreek": "160f2a6c3e55fc6a2a0913a23181e8ee946645b9",
+  "lascivaroma/priapeia": "64d5d916d1220ec4db8a848ce74998e9b6cdec71",
+  "hlapin/ancJewLitCTS": "f3534557c6cae678bccbbf0d97ac2b2cdf71cc2e",
   "nevenjovanovic/sophocles-ajax-latinus": "aee7611f65a30b8fe17f1833154988c811e886b3",
-  "PersDigUMD/PDL": "master"
+  "PersDigUMD/PDL": "1d9ec2450d62874f60dc5fd9e6c55c7048c5a36c"
 }

--- a/corpus.json
+++ b/corpus.json
@@ -3,7 +3,7 @@
   "PerseusDL/canonical-greekLit": "8403e88376cd3e844d2c93d79f05742788b971c7",
   "OpenGreekAndLatin/csel-dev": "fe80c57e88302917eaeac5dc6ecc81be5f3fb83a",
   "PerseusDL/canonical-farsiLit": "1ce632ece8a2af0646195a0531f5e8f39b161f72",
-  "PerseusDL/canonical-pdlpsci": "ff20d572cfdfeac871322ca07db4d34c5b7807da",
+  "PerseusDL/canonical-pdlpsci": "b7455f5961eca47ffec95556e6740bfbec3f8dd7",
   "OpenGreekAndLatin/First1KGreek": "160f2a6c3e55fc6a2a0913a23181e8ee946645b9",
   "lascivaroma/priapeia": "64d5d916d1220ec4db8a848ce74998e9b6cdec71",
   "hlapin/ancJewLitCTS": "f3534557c6cae678bccbbf0d97ac2b2cdf71cc2e",


### PR DESCRIPTION
- Updates the corpus to reference [PerseusDL/canonical-pdlpsci-00.19](https://github.com/PerseusDL/canonical-pdlpsci/releases/tag/0.0.19)
- Pins other collections in place

Moving forward, the team will be working to establish a repeatable update and release process, with the long-term goal of automated releases triggered by HookTest (see [scaife-viewer/scaife-viewer/issues/175](https://github.com/scaife-viewer/scaife-viewer/issues/175))