### PR TITLE
Update PDL Greek Literature to 0.0.1076: 2019-02-23

### DIFF
--- a/corpus.json
+++ b/corpus.json
@@ -1,6 +1,6 @@
 {
   "PerseusDL/canonical-latinLit": "c001efb82bc26ba95e935ce2fb4756d1dff0a688",
-  "PerseusDL/canonical-greekLit": "8403e88376cd3e844d2c93d79f05742788b971c7",
+  "PerseusDL/canonical-greekLit": "7d369824dae81c5b4bc94943254b086d5906e47f",
   "OpenGreekAndLatin/csel-dev": "fe80c57e88302917eaeac5dc6ecc81be5f3fb83a",
   "PerseusDL/canonical-farsiLit": "1ce632ece8a2af0646195a0531f5e8f39b161f72",
   "PerseusDL/canonical-pdlpsci": "eeccc4155d16ecae95b890fa994da87f6ed31906",


### PR DESCRIPTION
Updates the corpus to reference [PerseusDL/canonical-greekLit-0.0.1076](https://github.com/PerseusDL/canonical-greekLit/releases/tag/0.0.1076)