### PR TITLE
Update PDL Political Science Collection to 0.0.56 release

### DIFF
--- a/corpus.json
+++ b/corpus.json
@@ -3,7 +3,7 @@
   "PerseusDL/canonical-greekLit": "8403e88376cd3e844d2c93d79f05742788b971c7",
   "OpenGreekAndLatin/csel-dev": "fe80c57e88302917eaeac5dc6ecc81be5f3fb83a",
   "PerseusDL/canonical-farsiLit": "1ce632ece8a2af0646195a0531f5e8f39b161f72",
-  "PerseusDL/canonical-pdlpsci": "eeccc4155d16ecae95b890fa994da87f6ed31906",
+  "PerseusDL/canonical-pdlpsci": "2bd7e1d2acec2c442d3c676f50d15eac565e9457",
   "OpenGreekAndLatin/First1KGreek": "160f2a6c3e55fc6a2a0913a23181e8ee946645b9",
   "lascivaroma/priapeia": "64d5d916d1220ec4db8a848ce74998e9b6cdec71",
   "hlapin/ancJewLitCTS": "f3534557c6cae678bccbbf0d97ac2b2cdf71cc2e",


### PR DESCRIPTION
Updates the corpus to reference [PerseusDL/canonical-pdlpsci-0.0.56](https://github.com/PerseusDL/canonical-pdlpsci/releases/tag/0.0.56)