### PR TITLE
Extract repository metadata at ingestion time

### DIFF
--- a/corpus.json
+++ b/corpus.json
@@ -9,6 +9,6 @@
   "lascivaroma/priapeia": "3dfc11fe1bbbe5f34c435e6cd56cc277cdacbe8f",
   "hlapin/ancJewLitCTS": "f3534557c6cae678bccbbf0d97ac2b2cdf71cc2e",
   "nevenjovanovic/sophocles-ajax-latinus": "aee7611f65a30b8fe17f1833154988c811e886b3",
-  "jacobwegner/PDL": "bd84a35249a26aebf3810604cbf901a31f83e65a",
+  "jacobwegner/PDL": "eca3d09f9516c85173bece362749d0cb40c261df",
   "jacobwegner/Multepal-CTS": "976a340223666380ece66a936bdd58330b822e40"
 }

--- a/scaife_cts_api/__main__.py
+++ b/scaife_cts_api/__main__.py
@@ -78,10 +78,8 @@ def do_load_repo(repo, ref, dest):
 def serve(preload):
     if preload:
         resolver.preload()
-    workers = os.environ.get("WEB_CONCURRENCY", "1")
     args = [
         "gunicorn",
-        f"--workers={workers}",
         "--log-config=logging.ini",
         "scaife_cts_api.app:app",
     ]

--- a/scaife_cts_api/app.py
+++ b/scaife_cts_api/app.py
@@ -31,6 +31,12 @@ def repos():
     with open(repos_json, "r") as f:
         return jsonify(json.loads(f.read()))
 
+@app.route("/corpus-metadata")
+def corpus_metadata():
+    repos_json = os.path.join(ROOT_DIR_PATH, ".scaife-viewer.json")
+    with open(repos_json, "r") as f:
+        return jsonify(json.loads(f.read()))
+
 
 @app.route("/healthz")
 def healthz():

--- a/scaife_cts_api/resolver.py
+++ b/scaife_cts_api/resolver.py
@@ -1,6 +1,17 @@
+import json
 import os
+from collections import defaultdict
+from glob import glob
 
-from capitains_nautilus.cts.resolver import NautilusCTSResolver
+from MyCapytain.errors import UndispatchedTextError
+from capitains_nautilus.cts.resolver import (
+    NautilusCTSResolver as BaseNautilusCTSResolver,
+)
+from MyCapytain.resources.collections.cts import (
+    XmlCtsTextgroupMetadata as TextGroup,
+    XmlCtsWorkMetadata as Work,
+    XmlCtsCitation as Citation,
+)
 from werkzeug.contrib.cache import FileSystemCache
 
 from .data import ROOT_DIR_PATH
@@ -21,6 +32,141 @@ CACHE_THRESHOLD = 0  # A 0 value is treated by the cache backend as
                      # "Nautilus_repository_GetMetadata_None" cache keys
                      # from being pruned.
 cache = FileSystemCache(cache_path, threshold=CACHE_THRESHOLD)
+
+
+class NautilusCTSResolver(BaseNautilusCTSResolver):
+
+    def extract_sv_metadata(self, folder):
+        metadata_path = os.path.join(folder, ".scaife-viewer.json")
+        try:
+            return json.load(open(metadata_path))
+        except FileNotFoundError:
+            print(f"{metadata_path} was not found")
+            return {}
+
+    def parse(self, resource=None):
+        # NOTE: Extracted from 2dae321722c06fe8873c5f06b3f8fdbd45f643c2
+        """Parse a list of directories ans
+        :param resource: List of folders
+        :param ret: Return a specific item ("inventory" or "texts")
+        """
+        if resource is None:
+            resource = self.__resources__
+        removing = []
+        # start sv-metadata customization
+        repo_urn_lookup = defaultdict()
+        # end sv-metadata customization
+        for folder in resource:
+            # start sv-metadata customization
+            repo_metadata = self.extract_sv_metadata(folder)
+            repo_metadata["texts"] = []
+            # end sv-metadata customization
+
+            textgroups = glob("{base_folder}/data/*/__cts__.xml".format(base_folder=folder))
+            for __cts__ in textgroups:
+                try:
+                    with open(__cts__) as __xml__:
+                        textgroup = TextGroup.parse(
+                            resource=__xml__
+                        )
+                        tg_urn = str(textgroup.urn)
+                    if tg_urn in self.dispatcher.collection:
+                        self.dispatcher.collection[tg_urn].update(textgroup)
+                    else:
+                        self.dispatcher.dispatch(textgroup, path=__cts__)
+
+                    for __subcts__ in glob("{parent}/*/__cts__.xml".format(parent=os.path.dirname(__cts__))):
+                        with open(__subcts__) as __xml__:
+                            work = Work.parse(
+                                resource=__xml__,
+                                parent=self.dispatcher.collection[tg_urn]
+                            )
+                            work_urn = str(work.urn)
+                            if work_urn in self.dispatcher.collection[tg_urn].works:
+                                self.dispatcher.collection[work_urn].update(work)
+
+                        for __textkey__ in work.texts:
+                            __text__ = self.dispatcher.collection[__textkey__]
+                            __text__.path = "{directory}/{textgroup}.{work}.{version}.xml".format(
+                                directory=os.path.dirname(__subcts__),
+                                textgroup=__text__.urn.textgroup,
+                                work=__text__.urn.work,
+                                version=__text__.urn.version
+                            )
+                            if os.path.isfile(__text__.path):
+                                try:
+                                    t = self.read(__textkey__, __text__.path)
+                                    cites = list()
+                                    for cite in [c for c in t.citation][::-1]:
+                                        if len(cites) >= 1:
+                                            cites.append(Citation(
+                                                xpath=cite.xpath.replace("'", '"'),
+                                                scope=cite.scope.replace("'", '"'),
+                                                name=cite.name,
+                                                child=cites[-1]
+                                            ))
+                                        else:
+                                            cites.append(Citation(
+                                                xpath=cite.xpath.replace("'", '"'),
+                                                scope=cite.scope.replace("'", '"'),
+                                                name=cite.name
+                                            ))
+                                    del t
+                                    __text__.citation = cites[-1]
+                                    self.logger.info("%s has been parsed ", __text__.path)
+                                    if __text__.citation.isEmpty() is True:
+                                        removing.append(__textkey__)
+                                        self.logger.error("%s has no passages", __text__.path)
+                                except Exception as E:
+                                    removing.append(__textkey__)
+                                    self.logger.error(
+                                        "%s does not accept parsing at some level (most probably citation) ",
+                                        __text__.path
+                                    )
+                                else:
+                                    # start sv-metadata customization
+                                    repo_metadata["texts"].append(
+                                        str(__text__.urn)
+                                    )
+                                    # end sv-metadata customization
+                            else:
+                                removing.append(__textkey__)
+                                self.logger.error("%s is not present", __text__.path)
+                except UndispatchedTextError as E:
+                    self.logger.error("Error dispatching %s ", __cts__)
+                    if self.RAISE_ON_UNDISPATCHED is True:
+                        raise E
+                except Exception as E:
+                    self.logger.error("Error parsing %s ", __cts__)
+
+            # start sv-metadata customization
+            if repo_metadata.get("repo"):
+                repo_urn_lookup[repo_metadata["repo"]] = repo_metadata
+            # end sv-metadata customization
+
+        for removable in removing:
+            del self.dispatcher.collection[removable]
+
+        removing = []
+
+        if self.REMOVE_EMPTY is True:
+            # Find resource with no readable descendants
+            for item in self.dispatcher.collection.descendants:
+                if item.readable != True and len(item.readableDescendants) == 0:
+                    removing.append(item.id)
+
+            # Remove them only if they have not been removed before
+            for removable in removing:
+                if removable in self.dispatcher.collection:
+                    del self.dispatcher.collection[removable]
+
+            # @@@ write out our own "inventory"
+        corpus_metadata_path = os.path.join(root_dir_path, ".scaife-viewer.json")
+        json.dump(list(repo_urn_lookup.values()), open(corpus_metadata_path, "w"), indent=2)
+
+        self.inventory = self.dispatcher.collection
+        return self.inventory
+
 
 resolver = NautilusCTSResolver(
     [


### PR DESCRIPTION
Adds a new endpoint (`/corpus-metadata`) that groups CTS version URNs by their source repository.

For each repository, the GitHub repository slug and the last SHA ingested are provided.