### PR TITLE
Target HookSet tarballs when possible

### DIFF
--- a/corpus.json
+++ b/corpus.json
@@ -1,14 +1,62 @@
 {
-  "PerseusDL/canonical-latinLit": "47239d3a181f64551267d7a166ee6573a6d44e67",
-  "PerseusDL/canonical-greekLit": "25c5fc1c3ed5dbda4c8f49b2567fe50449fb2b02",
-  "OpenGreekAndLatin/csel-dev": "35c62f2df3112086d615946adf77a7e04aa000ee",
-  "PerseusDL/canonical-farsiLit": "1ce632ece8a2af0646195a0531f5e8f39b161f72",
-  "PerseusDL/canonical-pdlpsci": "8acfebb2e76bf48f243b3c84e4b65c4ceae8b7a6",
-  "OpenGreekAndLatin/First1KGreek": "574344dd21783a9659874c9782112ad91772f08f",
-  "OpenGreekAndLatin/Latin": "ff5b4bb27d867794dd0c2e0cbadc3aca63e50d17",
-  "lascivaroma/priapeia": "3dfc11fe1bbbe5f34c435e6cd56cc277cdacbe8f",
-  "hlapin/ancJewLitCTS": "f3534557c6cae678bccbbf0d97ac2b2cdf71cc2e",
-  "nevenjovanovic/sophocles-ajax-latinus": "aee7611f65a30b8fe17f1833154988c811e886b3",
-  "jacobwegner/PDL": "eca3d09f9516c85173bece362749d0cb40c261df",
-  "jacobwegner/Multepal-CTS": "976a340223666380ece66a936bdd58330b822e40"
+  "PerseusDL/canonical-latinLit": {
+    "ref": "0.0.843",
+    "sha": "ae36df4f6407544a661ae8f9f22ba2adcb893e96",
+    "tarball_url": "https://api.github.com/repos/PerseusDL/canonical-latinLit/tarball/0.0.843"
+  },
+  "PerseusDL/canonical-greekLit": {
+    "ref": "0.0.2781",
+    "sha": "1007df81237e3e4efc17bf7f0d03252e64a1b9d6",
+    "tarball_url": "https://api.github.com/repos/PerseusDL/canonical-greekLit/tarball/0.0.2781"
+  },
+  "OpenGreekAndLatin/csel-dev": {
+    "ref": "1.0.221",
+    "sha": "34643e103acdd1dc49dd74d92b0f272ca345aea4",
+    "tarball_url": "https://api.github.com/repos/OpenGreekAndLatin/csel-dev/tarball/1.0.221"
+  },
+  "PerseusDL/canonical-farsiLit": {
+    "ref": "0.0.11",
+    "sha": "a26b9a0f62aabd970a9fac26afa60d83e8a38823",
+    "tarball_url": "https://api.github.com/repos/PerseusDL/canonical-farsiLit/tarball/0.0.11"
+  },
+  "PerseusDL/canonical-pdlpsci": {
+    "ref": "0.0.56",
+    "sha": "2bd7e1d2acec2c442d3c676f50d15eac565e9457",
+    "tarball_url": "https://api.github.com/repos/PerseusDL/canonical-pdlpsci/tarball/0.0.56"
+  },
+  "OpenGreekAndLatin/First1KGreek": {
+    "ref": "1.1.5222",
+    "sha": "8a96ef98161e6fc4795ed783623bcae2c7e50ebd",
+    "tarball_url": "https://api.github.com/repos/OpenGreekAndLatin/First1KGreek/tarball/1.1.5222"
+  },
+  "OpenGreekAndLatin/Latin": {
+    "ref": "v1.10.0",
+    "sha": "ff5b4bb27d867794dd0c2e0cbadc3aca63e50d17",
+    "tarball_url": "https://api.github.com/repos/OpenGreekAndLatin/Latin/tarball/v1.10.0"
+  },
+  "lascivaroma/priapeia": {
+    "ref": "1.1.18",
+    "sha": "0a75c5c2fba85cef125555ea35029409585c54cb",
+    "tarball_url": "https://api.github.com/repos/lascivaroma/priapeia/tarball/1.1.18"
+  },
+  "hlapin/ancJewLitCTS": {
+    "ref": "0.1.50",
+    "sha": "f3534557c6cae678bccbbf0d97ac2b2cdf71cc2e",
+    "tarball_url": "https://api.github.com/repos/hlapin/ancJewLitCTS/tarball/0.1.50"
+  },
+  "nevenjovanovic/sophocles-ajax-latinus": {
+    "ref": "master",
+    "sha": "aee7611f65a30b8fe17f1833154988c811e886b3",
+    "tarball_url": "https://api.github.com/repos/nevenjovanovic/sophocles-ajax-latinus/tarball/aee7611f65a30b8fe17f1833154988c811e886b3"
+  },
+  "jacobwegner/PDL": {
+    "ref": "v0.0.2",
+    "sha": "eca3d09f9516c85173bece362749d0cb40c261df",
+    "tarball_url": "https://api.github.com/repos/jacobwegner/PDL/tarball/v0.0.2"
+  },
+  "jacobwegner/Multepal-CTS": {
+    "ref": "v0.0.1-rc4",
+    "sha": "f101dd39a7f98eea0442678cac4f83306707d51a",
+    "tarball_url": "https://api.github.com/repos/jacobwegner/Multepal-CTS/tarball/v0.0.1-rc4"
+  }
 }

--- a/scaife_cts_api/__main__.py
+++ b/scaife_cts_api/__main__.py
@@ -44,10 +44,8 @@ def loadcorpus(root_dir):
         f.write(json.dumps(dict(metadata)))
 
 
-def write_repo_metadata(repo, data, dest):
-    tarball_path = data.pop("tarball_path")
-    sv_metadata_path = os.path.join(dest, tarball_path, ".scaife-viewer.json")
-    json.dump(data, open(sv_metadata_path, "w"), indent=2)
+def write_repo_metadata(metadata_path, data):
+    json.dump(data, open(metadata_path, "w"), indent=2)
 
 
 def do_load_repo(repo, data, dest):
@@ -61,12 +59,10 @@ def do_load_repo(repo, data, dest):
         "repo": repo,
         "sha": sha,
         "ref": ref,
-        # include the extracted folder path for the tarball
-        # when retrieved from the GitHub API
-        "tarball_path": tarball_path,
         "tarball_url": tarball_url,
     }
-    write_repo_metadata(repo, repo_metadata, dest)
+    metadata_path = os.path.join(absolute_tarball_path, ".scaife-viewer.json")
+    write_repo_metadata(metadata_path, repo_metadata)
     return repo_metadata
 
 

--- a/scaife_cts_api/__main__.py
+++ b/scaife_cts_api/__main__.py
@@ -53,7 +53,7 @@ def write_repo_metadata(repo, data, dest):
 def do_load_repo(repo, data, dest):
     ref = data["ref"]
     sha = data["sha"]
-    tarball_url = f"https://api.github.com/repos/{repo}/tarball/{sha}"
+    tarball_url = data["tarball_url"]
     tarball_path = f"{repo.replace('/', '-')}-{ref}-{sha[:7]}"
     absolute_tarball_path = os.path.join(dest, tarball_path)
     load_repo(tarball_url, absolute_tarball_path)

--- a/scaife_cts_api/__main__.py
+++ b/scaife_cts_api/__main__.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 import click
 
 from . import resolver
-from .data import ROOT_DIR_PATH, load_repo, resolve_commit
+from .data import ROOT_DIR_PATH, load_repo
 
 
 @click.group()
@@ -31,10 +31,10 @@ def loadcorpus(root_dir):
         repos = json.loads(fp.read())
     fs = {}
     with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
-        for repo, ref in repos.items():
+        for repo, data in repos.items():
             dest = os.path.join(root_dir, "data")
-            f = executor.submit(do_load_repo, repo, ref, dest)
-            fs[f] = (repo, ref)
+            f = executor.submit(do_load_repo, repo, data, dest)
+            fs[f] = (repo, data["ref"])
         for f in concurrent.futures.as_completed(fs):
             repo, ref = fs[f]
             data = f.result()
@@ -45,24 +45,25 @@ def loadcorpus(root_dir):
 
 
 def write_repo_metadata(repo, data, dest):
-    sv_metadata_path = os.path.join(dest, data["tarball_path"], ".scaife-viewer.json")
-    metadata = {
-        "repo": repo,
-        "sha": data["sha"],
-    }
-    json.dump(metadata, open(sv_metadata_path, "w"), indent=2)
+    tarball_path = data.pop("tarball_path")
+    sv_metadata_path = os.path.join(dest, tarball_path, ".scaife-viewer.json")
+    json.dump(data, open(sv_metadata_path, "w"), indent=2)
 
 
-def do_load_repo(repo, ref, dest):
-    sha = resolve_commit(repo, ref)
+def do_load_repo(repo, data, dest):
+    ref = data["ref"]
+    sha = data["sha"]
     tarball_url = f"https://api.github.com/repos/{repo}/tarball/{sha}"
     tarball_path = f"{repo.replace('/', '-')}-{sha[:7]}"
     load_repo(tarball_url, dest)
     repo_metadata = {
+        "repo": repo,
         "sha": sha,
+        "ref": ref,
         # include the extracted folder path for the tarball
         # when retrieved from the GitHub API
         "tarball_path": tarball_path,
+        "tarball_url": tarball_url,
     }
     write_repo_metadata(repo, repo_metadata, dest)
     return repo_metadata

--- a/scaife_cts_api/__main__.py
+++ b/scaife_cts_api/__main__.py
@@ -54,8 +54,9 @@ def do_load_repo(repo, data, dest):
     ref = data["ref"]
     sha = data["sha"]
     tarball_url = f"https://api.github.com/repos/{repo}/tarball/{sha}"
-    tarball_path = f"{repo.replace('/', '-')}-{sha[:7]}"
-    load_repo(tarball_url, dest)
+    tarball_path = f"{repo.replace('/', '-')}-{ref}-{sha[:7]}"
+    absolute_tarball_path = os.path.join(dest, tarball_path)
+    load_repo(tarball_url, absolute_tarball_path)
     repo_metadata = {
         "repo": repo,
         "sha": sha,

--- a/scaife_cts_api/data.py
+++ b/scaife_cts_api/data.py
@@ -20,24 +20,3 @@ def load_repo(tarball_url, dest):
     os.close(w)
     proc.wait()
 
-
-def resolve_commit(repo, ref):
-    if re.match(r"^[a-f0-9]{40}$", ref):
-        return ref
-    ref_url = f"https://api.github.com/repos/{repo}/git/refs/heads/{ref}"
-    headers = {
-        "Accept": "application/vnd.github.v3+json",
-    }
-    resp = requests.get(ref_url, headers=headers)
-    if resp.status_code == 404:
-        tag_url = f"https://api.github.com/repos/{repo}/git/tags/{ref}"
-        resp = requests.get(tag_url, headers=headers)
-        if resp.status_code == 404:
-            raise Exception(f"{repo}: ref ({ref}) not found")
-        else:
-            resp.raise_for_status()
-            ref_obj = resp.json()["object"]
-    else:
-        resp.raise_for_status()
-        ref_obj = resp.json()["object"]
-    return ref_obj["sha"]

--- a/scaife_cts_api/data.py
+++ b/scaife_cts_api/data.py
@@ -12,7 +12,8 @@ def load_repo(tarball_url, dest):
     resp = requests.get(tarball_url, stream=True)
     resp.raise_for_status()
     r, w = os.pipe()
-    proc = subprocess.Popen(["tar", "-zxf", "-", "-C", dest], stdin=r)
+    os.makedirs(dest, exist_ok=True)
+    proc = subprocess.Popen(["tar", "-zxf", "-", "-C", dest, "--strip-components", "1"], stdin=r)
     os.close(r)
     for chunk in resp.iter_content(chunk_size=4092):
         if chunk:

--- a/scaife_cts_api/update_corpus_shas.py
+++ b/scaife_cts_api/update_corpus_shas.py
@@ -28,6 +28,8 @@ def main():
         try:
             latest_release = repo.get_latest_release()
             ref = latest_release.tag_name
+            # NOTE: latest_commit_sha will differ from latest_release.target_committish, because
+            # the release was created and then the tag was advanced if a HookSet was used
             latest_commit_sha = repo.get_commit(ref).sha
             tarball_url = latest_release.tarball_url
         except UnknownObjectException:


### PR DESCRIPTION
Refactors how repos are pinned in corpus.json:

- If a release is present, use the commit SHA tied to the release tag.  For repos using [HookTest](https://github.com/Capitains/HookTest), the commit SHA is never merged back to the main / master branch
- For other repos, use the latest commit on the default branch
- Add `tarball_url` to `/repos` endpoint (so that we can retrieve the tarball for the local resolver when indexing)